### PR TITLE
Small series page parsing fix

### DIFF
--- a/kinopoisk/movie/sources.py
+++ b/kinopoisk/movie/sources.py
@@ -108,7 +108,9 @@ class MovieSeries(KinopoiskPage):
             if '21px' not in season['style']:
                 continue
 
-            year = self.prepare_int(season.nextSibling.string[:4])
+
+
+            year = self.prepare_int(season.nextSibling.split(',')[0])
             tbody = season.parent.parent.parent
             episodes = []
             for tr in tbody.findAll('tr')[1:]:


### PR DESCRIPTION
Looks like Kinopoisk is displaying season year as 0 when it doesn't have the data (e.g. season 4 here: http://www.kinopoisk.ru/film/508161/episodes/ ). This is just a small fix to prevent parsing from failing when that happens.
All tests pass.
