### PR TITLE
fix regex for person.name_original

### DIFF
--- a/kinopoisk/person/sources.py
+++ b/kinopoisk/person/sources.py
@@ -50,7 +50,7 @@ class PersonMainPage(KinopoiskPage):
         if name:
             instance.name = self.prepare_str(name[0])
 
-        name_original = re.compile(r'<span itemprop="alternativeHeadline">([\w\s]+)\s+</span>').findall(content)
+        name_original = re.compile(r'<span itemprop="alternateName">([A-Z]\'?[- a-zA-Z]+)</span>').findall(content)
         if name_original:
             instance.name_original = self.prepare_str(name_original[0])
 


### PR DESCRIPTION
Fix regex for original name of person because current regex doesn't find names like [Nikolaj Coster-Waldau](https://www.kinopoisk.ru/name/47200/) and names with apostrophes. Also I updated value of attribute `itemprop` which one contains original name. 