### PR TITLE
fix invalid literal for int() with base 10: 'city'

### DIFF
--- a/kinopoisk/movie/sources.py
+++ b/kinopoisk/movie/sources.py
@@ -116,7 +116,10 @@ class MovieLink(KinopoiskPage):
         title_en = self.extract('title_en', to_str=True)
         rating = self.extract('rating')
 
-        self.instance.id = self.prepare_int(url.split('/')[2])
+        if 'afisha' not in url:
+            self.instance.id = self.prepare_int(url.split('/')[2])
+        else:
+            pass
         self.instance.title = self.extract_title()
         self.instance.series = 'сериал' in self.extract('title')
 


### PR DESCRIPTION
Fix https://github.com/ramusus/kinopoiskpy/issues/67 and https://github.com/ramusus/kinopoiskpy/issues/68