### PR TITLE
fix year bug

### DIFF
--- a/kinopoisk/movie/sources.py
+++ b/kinopoisk/movie/sources.py
@@ -121,7 +121,10 @@ class MovieLink(KinopoiskPage):
         self.instance.series = 'сериал' in self.extract('title')
 
         if years:
-            self.instance.year = self.prepare_int(years[:4])
+            year = years[:4]
+            if years[-3:len(years)] == '...':
+                year = str(datetime.datetime.now().year)
+            self.instance.year = self.prepare_int(year)
 
         if 'мин' in title_en:
             values = title_en.split(', ')

--- a/kinopoisk/movie/sources.py
+++ b/kinopoisk/movie/sources.py
@@ -122,7 +122,7 @@ class MovieLink(KinopoiskPage):
 
         if years:
             year = years[:4]
-            if years[-3:len(years)] == '...':
+            if years == ' – ...':
                 year = str(datetime.datetime.now().year)
             self.instance.year = self.prepare_int(year)
 


### PR DESCRIPTION
Found years like ' - ...'
Example - https://www.kinopoisk.ru/index.php?kp_query=Бегущий+по+лезвию

<img width="580" alt="Screenshot 2023-11-29 at 14 09 24" src="https://github.com/ramusus/kinopoiskpy/assets/42540020/f9424b1d-46fa-469f-8408-9048a83a67a1">